### PR TITLE
outro: remove cutscene

### DIFF
--- a/RemoveOutroMod/RemoveOutroMod.lua
+++ b/RemoveOutroMod/RemoveOutroMod.lua
@@ -1,10 +1,58 @@
-ModUtil.RegisterMod("RemoveOutroMod")
+--[[
+    RemoveCutscenes
+    Author:
+        Museus (Discord: Museus#7777)
 
-ModUtil.BaseOverride("EndEarlyAccessPresentation", function ()
-	CurrentRun.ActiveBiomeTimer = false
-	
-	thread( Kill, CurrentRun.Hero )
-	wait( 0.15 )
+    Optionally removes intro and outro cutscenes to runs
+]]
+ModUtil.RegisterMod("RemoveCutscenes")
 
-	FadeIn({ Duration = 0.5 })
-end, RemoveOutroMod)
+local config = {
+    ModName = "RemoveCutscenes",
+    RemoveIntro = true,
+    RemoveOutro = true,
+}
+RemoveCutscenes.config = config
+
+if ModConfigMenu then
+  ModConfigMenu.Register(config)
+end
+
+-- Remove starting cutscene
+ModUtil.WrapBaseFunction("ShowRunIntro", function( baseFunc )
+    if config.RemoveIntro then
+        return
+    end
+
+    baseFunc()
+end, RemoveCutscenes)
+
+
+ModUtil.WrapBaseFunction("EndEarlyAccessPresentation", function ( baseFunc )
+    if config.RemoveOutro then
+        CurrentRun.ActiveBiomeTimer = false
+
+        thread( Kill, CurrentRun.Hero )
+        wait( 0.15 )
+
+        FadeIn({ Duration = 0.5 })
+        return
+    end
+
+    baseFunc()
+end, RemoveCutscenes)
+
+
+-- Scripts/RoomManager.lua : 1874
+ModUtil.WrapBaseFunction("StartRoom", function ( baseFunc, currentRun, currentRoom )
+    PrintUtil.showModdedWarning()
+
+    baseFunc(currentRun, currentRoom)
+end, RemoveCutscenes)
+
+-- Scripts/UIScripts.lua : 145
+ModUtil.WrapBaseFunction("ShowCombatUI", function ( baseFunc, flag )
+    PrintUtil.showModdedWarning()
+
+    baseFunc(flag)
+end, RemoveCutscenes)

--- a/RemoveOutroMod/RemoveOutroMod.lua
+++ b/RemoveOutroMod/RemoveOutroMod.lua
@@ -1,0 +1,10 @@
+ModUtil.RegisterMod("RemoveOutroMod")
+
+ModUtil.BaseOverride("EndEarlyAccessPresentation", function ()
+	CurrentRun.ActiveBiomeTimer = false
+	
+	thread( Kill, CurrentRun.Hero )
+	wait( 0.15 )
+
+	FadeIn({ Duration = 0.5 })
+end, RemoveOutroMod)

--- a/RemoveOutroMod/modfile.txt
+++ b/RemoveOutroMod/modfile.txt
@@ -1,0 +1,8 @@
+-: Remove Outros Mod
+    Author(s) -
+      Museus (Discord: Museus#7777) 
+  This mod removes the outro upon leaving the surface after killing Hades.
+  Instead you just die and go back to the House.
+:-
+
+Import "RemoveOutroMod.lua"

--- a/RemoveOutroMod/modfile.txt
+++ b/RemoveOutroMod/modfile.txt
@@ -1,8 +1,8 @@
--: Remove Outros Mod
-    Author(s) -
-      Museus (Discord: Museus#7777) 
-  This mod removes the outro upon leaving the surface after killing Hades.
-  Instead you just die and go back to the House.
+-: RemoveCutscenes
+    Author:
+        Museus (Discord: Museus#7777)
+
+  Optionally removes the intro cutscene and outro cutscenes to runs
 :-
 
-Import "RemoveOutroMod.lua"
+Import "RemoveCutscenes.lua"


### PR DESCRIPTION
Removes the outro cutscene that happens every time you die, by overriding the function that handles it.

Closes #15 