### PR TITLE
Fix hammers at the start of the run, so that they will give the same rewards.

### DIFF
--- a/FixedHammers/FixedHammers.lua
+++ b/FixedHammers/FixedHammers.lua
@@ -23,7 +23,6 @@ ModUtil.WrapBaseFunction("StartNewRun", function(baseFunc, ...)
 
   -- reset the mod
   FixedHammers.Hammers = {}
-  FixedHammers.NextHammer = 1
 
   -- determine eligible hammers (for the current weapon)
   local eligibleHammers = GetEligibleHammers()
@@ -36,9 +35,9 @@ ModUtil.WrapBaseFunction("StartNewRun", function(baseFunc, ...)
 end, FixedHammers)
 
 ModUtil.WrapBaseFunction("SetTraitsOnLoot", function(baseFunc, lootData, args)
-  if config.UseFixedHammers and FixedHammers.Hammers then
-    local hammersInOrder = FixedHammers.Hammers[FixedHammers.NextHammer]
-    FixedHammers.NextHammer = 2
+  if lootData.Name == "WeaponUpgrade" and config.UseFixedHammers and FixedHammers.Hammers then
+    local previousHammers = CurrentRun.LootTypeHistory.WeaponUpgrade or 0
+    local hammersInOrder = FixedHammers.Hammers[previousHammers + 1]
 
     local eligibleHammers = GetEligibleHammers()
     local upgradeOptions = {}

--- a/FixedHammers/FixedHammers.lua
+++ b/FixedHammers/FixedHammers.lua
@@ -1,0 +1,56 @@
+ModUtil.RegisterMod("FixedHammers")
+
+local config = {
+  ModName = "Fixed Hammers",
+  UseFixedHammers = true
+}
+
+if ModConfigMenu then
+  ModConfigMenu.Register(config)
+end
+
+function FixedHammers.GetEligibleHammers()
+  local eligibleHammers = {}
+
+  local loot = DeepCopyTable( LootData["WeaponUpgrade"] )
+  loot.RarityChances = {}
+  loot.ForceCommon = true
+  for _, hammer in pairs(GetEligibleUpgrades({}, loot, LootData["WeaponUpgrade"])) do
+    table.insert(eligibleHammers, hammer.ItemName)
+  end
+
+  return eligibleHammers
+end
+
+ModUtil.WrapBaseFunction("StartNewRun", function(baseFunc, ...)
+  -- initialize everything else first
+  baseFunc(...)
+
+  -- reset the mod
+  FixedHammers.Hammers = {}
+  FixedHammers.NextHammer = 1
+
+  -- determine eligible hammers (for the current weapon)
+  local eligibleHammers = GetEligibleHammers()
+  for _, name in pairs(eligibleHammers) do
+    print(name)
+  end
+
+  -- shuffle the hammers, creating two permutations
+  FixedHammers.Hammers[1] = FYShuffle(eligibleHammers)
+  FixedHammers.Hammers[2] = FYShuffle(eligibleHammers)
+end, FixedHammers)
+
+ModUtil.WrapBaseFunction("SetTraitsOnLoot", function(baseFunc, lootData, args)
+  if config.UseFixedHammers and FixedHammers.Hammers then
+    local hammersInOrder = FixedHammers.Hammers[FixedHammers.NextHammer]
+    local eligibleHammers = GetEligibleHammers()
+    local upgradeOptions = {}
+    for _, hammer in pairs(hammersInOrder) do
+      
+    end
+    return baseFunc(lootData, args)
+  else
+    return baseFunc(lootData, args)
+  end
+end, FixedHammers)

--- a/FixedHammers/LICENSE
+++ b/FixedHammers/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 paradigmsort
+Copyright (c) 2021 paradigmsort
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/FixedHammers/LICENSE
+++ b/FixedHammers/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 paradigmsort
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/FixedHammers/modfile.txt
+++ b/FixedHammers/modfile.txt
@@ -1,0 +1,1 @@
+Import "FixedHammers.lua"


### PR DESCRIPTION
At the start of the run, generate two random permutations of eligible hammers.

When you pick up the first hammer, you'll be offered the first 3 from permutation 1.
When you pick up the second hammer, you'll be offered the first 3 that are still eligible (skipping over ineligible options) from permutation 2.

This ensures that the hammer 2 for both runners is as similar as possible.

Addresses #10 and #11 