### PR TITLE
QuickRestart: if RtaTimer exists, restart it

### DIFF
--- a/QuickRestart/QuickRestart.lua
+++ b/QuickRestart/QuickRestart.lua
@@ -27,6 +27,10 @@ function QuickRestart.ResetRun(triggerArgs)
     return
   end
 
+  if RtaTimer then
+    RtaTimer__ResetRtaTimer()
+  end
+
   KillHero( CurrentRun.Hero, triggerArgs )
 end
 


### PR DESCRIPTION
Requested by webs, seems like a great fix for the "when do we restart RtaTimer" issue

Closes #49 