### PR TITLE
QuickRestart: Disallow in Thanatos Encounters until enemies spawn

### DIFF
--- a/QuickRestart/QuickRestart.lua
+++ b/QuickRestart/QuickRestart.lua
@@ -19,7 +19,12 @@ function QuickRestart.CanReset()
   if not (ShowingCombatUI or false) then return false end
 
   -- If we're in a Thanatos Room, enemies must have already spawned
-  if (CurrentRun.CurrentRoom.Encounter.ThanatosId ~= nil and GetActiveEnemyCount() == 0) then return false end
+  if (CurrentRun ~= nil and CurrentRun.CurrentRoom ~= nil and
+      CurrentRun.CurrentRoom.Encounter ~= nil and
+      CurrentRun.CurrentRoom.Encounter.ThanatosId ~= nil
+      and GetActiveEnemyCount() == 0) then
+    return false
+  end
 
   return true
 end

--- a/QuickRestart/QuickRestart.lua
+++ b/QuickRestart/QuickRestart.lua
@@ -16,7 +16,10 @@ function QuickRestart.CanReset()
   if not IsEmpty( CurrentRun.Hero.FreezeInputKeys ) then return false end
 
   -- Combat UI must be visible
-	if not (ShowingCombatUI or false) then return false end
+  if not (ShowingCombatUI or false) then return false end
+
+  -- If we're in a Thanatos Room, enemies must have already spawned
+  if (CurrentRun.CurrentRoom.Encounter.ThanatosId ~= nil and GetActiveEnemyCount() == 0) then return false end
 
   return true
 end


### PR DESCRIPTION
Fixes an issue where resetting before Thanatos fully spawns breaks things