### PR TITLE
Add HeatQuickDeath Mod

### DIFF
--- a/HadesSpeedrunningModpack/QualityOfLifeMenu.lua
+++ b/HadesSpeedrunningModpack/QualityOfLifeMenu.lua
@@ -328,6 +328,39 @@ function HSMConfigMenu.CreateQolMenu(screen)
   })
   screen.Components["HellModeToggleButton"].OnPressedFunctionName = "HellModeToggle.ToggleHellMode"
   itemLocationY = itemLocationY + itemSpacingY
+
+  -----------------------------
+  -- Heat Quick Death
+  -----------------------------
+  screen.Components["HeatQuickDeathTextBox"] = CreateScreenComponent({
+    Name = "BlankObstacle",
+    Scale = 1,
+    X = itemLocationX,
+    Y = itemLocationY,
+    Group = "Combat_Menu" })
+  CreateTextBox({
+    Id = screen.Components["HeatQuickDeathTextBox"].Id,
+    Text = "Enable Quick Death:",
+    Color = Color.BoonPatchCommon,
+    FontSize = 16,
+    OffsetX = 0, OffsetY = 0,
+    Font = "AlegrayaSansSCRegular",
+    ShadowBlur = 0, ShadowColor = { 0, 0, 0, 1 }, ShadowOffset = { 0,  2 },
+    Justification = "Left"
+  })
+  screen.Components["HeatQuickDeathCheckBox"] = CreateScreenComponent({
+    Name = "RadioButton",
+    Scale = 1,
+    X = itemLocationX + itemSpacingX,
+    Y = itemLocationY,
+    Group = "CombatMenu"
+  })
+  screen.Components["HeatQuickDeathCheckBox"].Config = "HeatQuickDeath.config.Enabled"
+  screen.Components["HeatQuickDeathCheckBox"].OnPressedFunctionName = "HSMConfigMenu__ToggleGenericConfigCheckBox"
+  HSMConfigMenu__UpdateGenericConfigCheckbox(screen, screen.Components["HeatQuickDeathCheckBox"])
+  itemLocationY = itemLocationY + itemSpacingY
+  
+
 end
 
 

--- a/HeatQuickDeath/HeatQuickDeath.lua
+++ b/HeatQuickDeath/HeatQuickDeath.lua
@@ -1,0 +1,24 @@
+--[[
+    HellModeToggle
+    Author:
+        Zyruvias (Discord: Zyruvias#3283)
+
+    Allows quick-reset to apply on death as well. Requires Quick Restart to be enabled.
+]]
+
+ModUtil.RegisterMod("HeatQuickDeath")
+
+local config = {
+    Enabled = true,
+}
+
+HeatQuickDeath.config = config;
+
+ModUtil.WrapBaseFunction("HandleDeath", function( baseFunc, currentRun, killer, killingUnitWeapon)
+    -- require both HeatQuickDeath and QuickRestart
+    if config.Enabled and QuickRestart.config.Enabled and not QuickRestart.UsedQuickRestart and not currentRun.Cleared then
+        QuickRestart.UsedQuickRestart = true;
+    end
+
+    return baseFunc(currentRun, killer, killingUnitWeapon);
+end, HeatQuickDeath)

--- a/HeatQuickDeath/modfile.txt
+++ b/HeatQuickDeath/modfile.txt
@@ -1,0 +1,6 @@
+-:
+  HellModeToggle v1.0
+  Authors:
+    Zyruvias (Discord: zyruvias#3283)
+:-
+Import "HeatQuickDeath.lua"


### PR DESCRIPTION
* Add HeatQuickDeath Mod: Dying can now emit a "Quick Reset" flag as if you had used Quick reset right before dying organically.
* Add HeatQuickDeath Mod option in QoL Menu