### PR TITLE
Fix ShowChamberNumber modfile.txt to be fully compatible with newer ModImporter versions

### DIFF
--- a/ShowChamberNumber/modfile.txt
+++ b/ShowChamberNumber/modfile.txt
@@ -1,3 +1,4 @@
+-:
     ShowChamberNumber
     Authors:
       Museus (Discord: Museus#7777)


### PR DESCRIPTION
The file was missing the `-:` from the first line to designate a comment. Previous versions of the mod importer did not care, but newer ones do so we should fix this.