### PR TITLE
Fix ShowChamberNumber/modfile for ModImporter compatibility

### DIFF
--- a/ShowChamberNumber/modfile.txt
+++ b/ShowChamberNumber/modfile.txt
@@ -1,3 +1,4 @@
+-:
     ShowChamberNumber
     Authors:
       Museus (Discord: Museus#7777)


### PR DESCRIPTION
`-:` was missing from the first line. This was not a problem for older versions of the mod importer, but is for newer ones.